### PR TITLE
docs: clarify photo API status and fix health/version endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,16 +35,19 @@ from .db import SessionLocal, engine
 from .config import settings
 from . import s3 as s3mod
 
+
 @app.get("/version")
 def version():
+    """Return build/version information for the server."""
     return {
-        "commit": os.getenv("GIT_COMMIT", os.getenv("COMMIT", "unknown")),
-        "buildDate": os.getenv("BUILD_DATE", "unknown"),
-        "apiMode": os.getenv("API_MODE", os.getenv("ENV", "unknown")),
+        "version": os.getenv("GIT_COMMIT", os.getenv("COMMIT", "unknown")),
+        "build": os.getenv("BUILD_DATE", "unknown"),
     }
+
 
 @app.get("/healthz")
 def healthz():
+    """Run simple checks for the database and S3."""
     db_status = "skipped"
     s3_status = "skipped"
     # DB ping
@@ -65,4 +68,11 @@ def healthz():
         s3_status = f"error: {type(e).__name__}"
     server_time = int(dt.datetime.utcnow().timestamp() * 1_000_000)
     ok = (db_status in ("ok", "skipped")) and (s3_status in ("ok", "skipped"))
-    return {"ok": ok, "db": db_status, "s3": s3_status, "serverTime": server_time}
+    status = "ok" if ok else "error"
+    return {
+        "status": status,
+        "ok": ok,
+        "db": db_status,
+        "s3": s3_status,
+        "serverTime": server_time,
+    }

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,280 +1,54 @@
+# Photo API (development)
 
-# Ente Museum FastAP Server (Mostly Compatible)
+This repository contains a FastAPI server that mimics a small portion of the [Ente](https://ente.io) photo storage API.
+The implementation is experimental and intended for local testing.  Only a subset of the real API is available and many
+features are stubs.  Use this server only for development and with test data.
 
-**Enhanced for full Ente Museum API compatibility with improved metadata support, standardized error handling, and multi-cloud configuration.**
+## Current features
 
-## Auth
+### Authentication
+- `POST /users/login` – email/password login returning `authToken`.
+- Session management endpoints: `GET /users/sessions`, `DELETE /users/sessions/{id}`,
+  `POST /users/sessions/revoke-others`, `DELETE /users/sessions/current`.
+- User records contain fields for E2EE keys and email verification, but the verification flow is not implemented.
 
-- `POST /users/login` → `{ "authToken", "tokenType": "bearer", "expiresIn": 86400 }`
-  - **✅ Ente Compatible**: Uses `authToken` field instead of `accessToken`
-  - **✅ Enhanced**: Supports all Ente client authentication patterns
-- Token accepted via `Authorization: Bearer` **or** `X-Auth-Token`, with `?token=` fallback.
-- Sessions:
-  - `GET /users/sessions` → list of active/inactive sessions (with IP, UA, client package/version).
-  - `DELETE /users/sessions/{sessionId}` → revoke one.
-  - `POST /users/sessions/revoke-others` → revoke all except current (or all, if token lacks JTI).
-  - `DELETE /users/sessions/current` → revoke current session.
-- **✅ New**: Enhanced user model with E2EE key support:
-  - `encryptedMasterKey`, `publicKey`, `encryptedPrivateKey`
-  - Email verification support with `isEmailVerified`
+### File upload and management
+- Presigned upload helpers: `GET /files/upload-urls`, `GET /files/multipart-upload-urls`, `POST /files/multipart-complete`.
+- Commit uploaded files with metadata using `POST /files`.
+- Update metadata: `PUT /files/update`, `PUT /files/thumbnail`, `PUT /files/magic-metadata`.
+- Retrieve files via 307 redirects to S3: `GET /files/download/{id}` and `GET /files/preview/{id}`.
+- Utility endpoints: `POST /files/info`, `POST /files/size`, `GET /files/duplicates`.
+- Trash workflow: `POST /files/trash`, `POST /files/restore`, `POST /files/delete`.
 
-## Uploads
+### Collections
+- Create and list collections: `POST /collections`, `GET /collections`.
+- Delta listing: `GET /collections/v2?sinceTime=...`.
+- Additional collection metadata fields are stored but not fully used by clients.
 
-- `GET /files/upload-urls` and `GET /files/multipart-upload-urls` → true S3 presigned URLs (PUT and upload_part).
-- `POST /files/multipart-complete` → server completes MPU with automatic replication.
-- `POST /files` (commit) supports `pubMagicMetadata` and optional `sha256`; server HEADs the object to fetch size and rejects missing uploads.
-- **✅ Enhanced**: Full support for Ente's encryption metadata fields
-- **✅ Automatic Replication**: Files automatically replicated based on user subscription
+### Storage
+- Uploads enforce a per‑user quota stored in the database.
+- `/storage` endpoints report usage, tier quotas and replication information.
+- Admin storage routes exist but do **not** include authentication; they are for development only.
 
-## File ops
+### Public links
+- `/public/collections` and related routes provide simple album links and optional guest uploads.
+- `/public/files/{token}` serves individual file links.
 
-- `POST /files/trash`, `POST /files/restore`, `POST /files/delete` (hard-delete requires trashed).
-- `GET /files/duplicates` groups by stored `sha256`.
-- `POST /files/info`, `POST /files/size`, `PUT /files/thumbnail`, `PUT /files/magic-metadata` retained.
-- `GET /files/download/{fileId}` and `/files/preview/{fileId}` return **307** to S3 presigned GET.
-- **✅ Enhanced File Metadata**: Now includes all Ente-compatible fields:
-  - `encryptedKey`, `keyDecryptionNonce`, `fileNonce`, `thumbnailNonce`
-  - `magicMetadata` with version support
-  - `pubMagicMetadata` for shared collections
-  - `etag`, `updatedAt` timestamps
-  - Enhanced `FileInfoItem` responses with full metadata
+### Operational endpoints
+- `GET /ping` – liveness check.
+- `GET /healthz` – readiness check (database and S3) returning `{"status": "ok"}` plus per-service details.
+- `GET /version` – build metadata with `{"version": ..., "build": ...}`.
 
-## Trash API
+## Limitations
+- Multi‑cloud replication is a placeholder: all tiers use the same S3 bucket unless separate buckets are configured.
+- Advanced Ente features such as email verification, shared album permissions, family plans and full client compatibility are missing.
+- Error handling and validation are minimal compared to the real service.
+- This server has not been security audited and should not be exposed to the internet.
 
-- `GET /trash/v2/diff?sinceTime=ISO8601` → trashed delta view.
-- `POST /trash/delete` → permanently delete selected trashed files.
-- `POST /trash/empty` → empty trash.
-
-## Public links & Albums
-
-- `POST /public/collections` → `{ "token", "url": "/albums/collection/<token>" }`.
-- `GET /public/collections/{token}` → 307 to `ALBUMS_BASE_URL/{token}`.
-- `GET /public/collections/{token}/preview/{fileId}` → 307 to S3 presigned GET.
-- `POST /public/collections/{token}/commit-file` → guest upload commit with the same body as `/files`.
-
-**Config:** same as v3; ensure bucket CORS allows `GET, PUT, HEAD` and the custom headers used by your clients.
-
-
-## Ops
-
-- `GET /ping` → liveness
-- `GET /healthz` → readiness (DB + S3)
-- `GET /version` → build/commit metadata
-
-## Collections
-
-- `POST /collections` → create new collection
-- `GET /collections` → list user collections
-- `GET /collections/v2?sinceTime=⟨microseconds|ISO8601⟩` → `{ serverTime, nextSince, collections: [{ id, name, updatedAtUs }] }`
-- **✅ Enhanced Collection Metadata**: Full Ente compatibility:
-  - `encryptedKey`, `keyDecryptionNonce` for E2EE
-  - `encryptedName`, `nameDecryptionNonce` for encrypted collection names
-  - `collectionType` (album, folder, etc.), `isShared`, `isPinned`
-  - `magicMetadata` and `pubMagicMetadata` with version support
-  - `createdAt`, `updatedAt` timestamps
-
-## Storage Management ✅ IMPLEMENTED
-
-**Storage quota and usage tracking with multi-tier support:**
-
-- `GET /storage/usage` → Current user's storage usage and quota (PRIMARY tier only)
-- `POST /storage/refresh` → Recalculate storage usage from actual files
-- `GET /storage/tier-quotas` → Get tier-specific quotas based on subscription
-- `GET /storage/replication-info` → Get replication rules and available tiers
-- `GET /storage/detailed-usage` → Detailed breakdown by tier including replicas
-
-**Admin endpoints:**
-- `PUT /storage/admin/quota/{userId}` → Set user's storage quota
-- `POST /storage/admin/bonus/{userId}` → Add bonus storage to user
-- `GET /storage/admin/usage/{userId}` → Get any user's storage usage
-
-**Features:**
-- ✅ **Quota enforcement**: Upload blocked when quota exceeded
-- ✅ **Real-time tracking**: Storage usage updated on file create/delete
-- ✅ **Subscription tiers**: Free (10GB), Paid (100GB), Family (2TB)
-- ✅ **Bonus storage**: Referral bonuses and promotions
-- ✅ **Multi-tier quotas**: Different limits per storage tier
-- ✅ **Usage calculation**: Automatic recalculation from actual files
-- ✅ **Replica exclusion**: Replicated files don't count against quotas
-- ✅ **Tier breakdown**: Detailed usage by PRIMARY/SECONDARY/COLD tiers
-
-**Storage Response Format:**
-```json
-{
-  "used": 1073741824,
-  "quota": 10737418240,
-  "totalQuota": 10737418240,
-  "available": 9663676416,
-  "usagePercentage": 10.0,
-  "formattedUsed": "1.0 GB",
-  "formattedQuota": "10.0 GB",
-  "formattedAvailable": "9.0 GB"
-}
+## Running locally
+```
+uvicorn app.main:app --reload
 ```
 
-**Detailed Usage Response Format:**
-```json
-{
-  "quota_usage": {
-    "used": 1073741824,
-    "quota": 10737418240,
-    "available": 9663676416,
-    "formatted_used": "1.0 GB"
-  },
-  "tier_breakdown": {
-    "primary": {
-      "usage": 1073741824,
-      "formatted": "1.0 GB",
-      "counts_against_quota": true
-    },
-    "secondary": {
-      "usage": 1073741824,
-      "formatted": "1.0 GB", 
-      "counts_against_quota": false
-    },
-    "cold": {
-      "usage": 1073741824,
-      "formatted": "1.0 GB",
-      "counts_against_quota": false
-    }
-  },
-  "replication_summary": {
-    "total_replicated": 2147483648,
-    "formatted_replicated": "2.0 GB",
-    "replication_ratio": 2.0
-  }
-}
-```
-
-**Equal Replication Policy:**
-- Only PRIMARY tier files count against user storage quotas
-- SECONDARY and COLD tier files are automatic replicas (free for everyone)
-- All users get unlimited replica storage regardless of subscription
-- Full multi-cloud replication for everyone - no discrimination
-- Equal treatment: Free users get the same replication as paid users
-
-## Accounts WebView bridge
-
-- `GET /users/accounts-token` → `{ accountsToken: base64(JWT) }`
-- **✅ Enhanced**: Uses configurable JWT settings for full Ente compatibility
-
-## Error Handling
-
-**✅ Standardized Ente-compatible error responses:**
-
-```json
-{
-  "error": "VALIDATION_ERROR",
-  "message": "Invalid input provided",
-  "details": [
-    {
-      "code": "INVALID_EMAIL",
-      "message": "Email format is invalid",
-      "field": "email"
-    }
-  ],
-  "requestId": "req_123456"
-}
-```
-
-## Configuration
-
-**✅ Enhanced Ente-compatible configuration options:**
-
-### Multi-cloud S3 Support ✅ IMPLEMENTED
-- `S3_B2_EU_CEN_BUCKET` - Primary hot storage (B2) - **Active**
-- `S3_WASABI_EU_CENTRAL_BUCKET` - Secondary hot storage - **Active**
-- `S3_SCW_EU_FR_BUCKET` - Cold storage - **Active**
-
-**Features:**
-- ✅ **Tier-aware uploads**: Upload to specific storage tiers
-- ✅ **Automatic failover**: Downloads fallback across tiers if object not found
-- ✅ **Automatic replication**: Server-side replication based on subscription
-- ✅ **Subscription-based tiers**: Free (PRIMARY), Paid (+SECONDARY), Family (+COLD)
-- ✅ **Multi-tier deletion**: Delete from all tiers or specific tier
-- ✅ **Object metadata**: Get object info with tier fallback
-- ✅ **Backward compatibility**: Existing code works without changes
-
-**Automatic Replication Rules:**
-- **All users**: PRIMARY → SECONDARY → COLD (equal replication for everyone)
-- **No discrimination**: Every user gets full multi-cloud redundancy
-- **Free replicas**: SECONDARY and COLD tiers don't count against quotas
-
-### App Endpoints
-- `ALBUMS_BASE_URL` - Albums web app endpoint
-- `CAST_BASE_URL` - Cast app endpoint  
-- `ACCOUNTS_BASE_URL` - Accounts app endpoint
-
-### Email Configuration
-- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`
-- `SMTP_FROM_EMAIL`, `SMTP_FROM_NAME`
-
-### Encryption Keys
-- `KEY_ENCRYPTION` - User email encryption key
-- `KEY_HASH` - Hash key for security
-
-### Accounts JWT
-- `ACCOUNTS_JWT_SECRET`, `ACCOUNTS_JWT_ISS`, `ACCOUNTS_JWT_AUD`
-- `ACCOUNTS_JWT_TTL_SEC` - Token TTL (default: 900s)
-
-### Feature Flags
-- `ENABLE_EMAIL_VERIFICATION` - Email verification (default: false)
-- `ENABLE_PUBLIC_SHARING` - Public sharing (default: true)
-- `ENABLE_FAMILY_PLANS` - Family plans (default: false)
-
-### Rate Limiting
-- `RATE_LIMIT_ENABLED` - Enable rate limiting (default: true)
-- `RATE_LIMIT_REQUESTS_PER_MINUTE` - Requests per minute (default: 60)
-
-## Compatibility Notes
-
-**✅ Full Ente Museum API Compatibility:**
-
-1. **Authentication**: Uses `authToken` instead of `accessToken`
-2. **Metadata**: Complete support for all Ente encryption metadata fields
-3. **Collections**: Enhanced with full E2EE and sharing metadata
-4. **Error Handling**: Standardized error response format
-5. **Configuration**: Supports all major Ente configuration parameters
-6. **Multi-cloud**: Ready for multi-cloud S3 deployment
-7. **Storage Management**: Full quota enforcement and usage tracking
-8. **Equal Replication**: All users get full multi-cloud replication regardless of subscription
-
-**Client Compatibility:**
-- ✅ Ente Photos mobile apps
-- ✅ Ente Photos web app
-- ✅ Ente Auth (basic functionality)
-- ✅ Public sharing and albums
-
-## Multi-cloud S3 Usage
-
-**✅ Tier-specific Operations:**
-
-```python
-from app.s3 import StorageTier, presign_put, presign_get
-
-# Upload to specific tier
-url = presign_put("user/file.jpg", tier=StorageTier.PRIMARY)
-
-# Download with automatic failover
-url = presign_get("user/file.jpg")  # Tries PRIMARY → SECONDARY → COLD
-
-# Upload to cold storage
-url = presign_put("archive/old-file.jpg", tier=StorageTier.COLD)
-```
-
-**Storage Tier Strategy:**
-- **PRIMARY**: Active user files, recent uploads
-- **SECONDARY**: Backup of active files, geographic redundancy  
-- **COLD**: Archive storage, infrequently accessed files
-
-**Automatic Features:**
-- New uploads go to PRIMARY tier by default
-- Downloads automatically try PRIMARY → SECONDARY → COLD
-- Completed uploads trigger replication scheduling
-- File deletions can target all tiers or specific tier
-
-**Migration from v5:**
-- Database migration required for new metadata fields
-- Update environment variables for new configuration options
-- Multi-cloud S3 buckets can be configured (optional)
-- Client apps should work without changes due to backward compatibility
+The server uses a local SQLite database file and an S3-compatible object store. Configuration
+options are documented in `app/config.py` and can be provided via environment variables.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 fastapi==0.111.0
 uvicorn==0.30.1
 python-multipart==0.0.9
-pydantic==2.7.1
-pydantic-settings==2.2.1
-SQLAlchemy==2.0.30
-alembic==1.13.1
+pydantic==2.11.8
+pydantic-settings==2.10.1
+SQLAlchemy==2.0.43
+alembic==1.16.5
 passlib[bcrypt]==1.7.4
 PyJWT==2.8.0
 boto3==1.34.162

--- a/tests/test_api_compat.py
+++ b/tests/test_api_compat.py
@@ -1,4 +1,3 @@
-import json
 from app.main import app
 from fastapi.testclient import TestClient
 

--- a/tests/test_api_compat.py
+++ b/tests/test_api_compat.py
@@ -1,0 +1,60 @@
+import json
+from app.main import app
+from fastapi.testclient import TestClient
+
+expected_paths = {
+    "/albums/collection/{token}": {"get"},
+    "/albums/file/{token}": {"get"},
+    "/collections": {"get", "post"},
+    "/collections/v2": {"get"},
+    "/files": {"post"},
+    "/files/count": {"get"},
+    "/files/data/preview-upload-url": {"get"},
+    "/files/delete": {"post"},
+    "/files/download/{file_id}": {"get"},
+    "/files/duplicates": {"get"},
+    "/files/info": {"post"},
+    "/files/magic-metadata": {"put"},
+    "/files/multipart-complete": {"post"},
+    "/files/multipart-upload-urls": {"get"},
+    "/files/preview/{file_id}": {"get"},
+    "/files/restore": {"post"},
+    "/files/size": {"post"},
+    "/files/thumbnail": {"put"},
+    "/files/trash": {"post"},
+    "/files/update": {"put"},
+    "/files/upload-urls": {"get"},
+    "/healthz": {"get"},
+    "/kex/add": {"put"},
+    "/kex/get": {"get"},
+    "/ping": {"get"},
+    "/public/collections": {"post"},
+    "/public/collections/{token}": {"get"},
+    "/public/collections/{token}/commit-file": {"post"},
+    "/public/collections/{token}/preview/{file_id}": {"get"},
+    "/public/files/{token}": {"get"},
+    "/storage/admin/bonus/{user_id}": {"post"},
+    "/storage/admin/quota/{user_id}": {"put"},
+    "/storage/admin/usage/{user_id}": {"get"},
+    "/storage/detailed-usage": {"get"},
+    "/storage/refresh": {"post"},
+    "/storage/replication-info": {"get"},
+    "/storage/tier-quotas": {"get"},
+    "/storage/usage": {"get"},
+    "/trash/delete": {"post"},
+    "/trash/empty": {"post"},
+    "/trash/v2/diff": {"get"},
+    "/users/accounts-token": {"get"},
+    "/users/login": {"post"},
+    "/users/sessions": {"get"},
+    "/users/sessions/current": {"delete"},
+    "/users/sessions/revoke-others": {"post"},
+    "/users/sessions/{session_id}": {"delete"},
+    "/version": {"get"},
+}
+
+def test_api_paths_match_backend_spec():
+    client = TestClient(app)
+    openapi = client.get("/openapi.json").json()
+    actual_paths = {path: set(info.keys()) for path, info in openapi["paths"].items()}
+    assert actual_paths == expected_paths


### PR DESCRIPTION
## Summary
- rewrite API docs to accurately describe implemented endpoints
- note limitations such as placeholder multi-cloud and missing advanced features
- document SQLite and S3 as the only required services
- update pydantic/SQLAlchemy dependencies to install on Python 3.12+
- align `/healthz` and `/version` responses with tests and document their JSON output
- add regression test enforcing parity with Ente backend's API paths

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50dff50108333b538e18b95b8fcc0