### PR TITLE
feat: support multiple s3 backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,8 @@ Run:
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-
-export ADMIN_EMAIL="admin@example.com"
-export ADMIN_PASSWORD="changeme"
-export JWT_SECRET="dev-secret"
-
-export S3_ENABLED=1
-export S3_ENDPOINT_URL="http://localhost:9000"
-export S3_REGION="us-east-1"
-export S3_ACCESS_KEY="minioadmin"
-export S3_SECRET_KEY="minioadmin"
-export S3_BUCKET="ente-objects"
-export S3_USE_PATH_STYLE=1
-export ALBUMS_BASE_URL="http://localhost:3002"
-
+cp config.example.toml config.toml
+# edit config.toml as needed (env vars override values)
 uvicorn app.main:app --reload
 # Swagger: http://localhost:8000/docs
 ```

--- a/app/config.py
+++ b/app/config.py
@@ -1,69 +1,96 @@
-
 from __future__ import annotations
 import os
-from pydantic_settings import BaseSettings
-from pydantic import Field
+import tomllib
+from pydantic import BaseModel, Field
 
-class Settings(BaseSettings):
+class Settings(BaseModel):
     app_name: str = "Museum‑subset (FastAPI)"
-    
-    # JWT Configuration
-    jwt_secret: str = Field(default=os.environ.get("JWT_SECRET", "dev-secret"))
-    jwt_issuer: str = "museum-subset"
-    jwt_exp_hours: int = int(os.environ.get("JWT_EXP_HOURS", "24"))
-    
-    # Admin Configuration
-    admin_email: str = os.environ.get("ADMIN_EMAIL", "admin@example.com")
-    admin_password: str = os.environ.get("ADMIN_PASSWORD", "changeme")
-    
-    # Database Configuration
-    database_url: str = os.environ.get("DATABASE_URL", "sqlite:///./museum.db")
-    
-    # S3 / MinIO Configuration
-    s3_enabled: bool = bool(int(os.environ.get("S3_ENABLED", "1")))
-    s3_endpoint_url: str = os.environ.get("S3_ENDPOINT_URL", "http://localhost:9000")
-    s3_region: str = os.environ.get("S3_REGION", "us-east-1")
-    s3_access_key: str = os.environ.get("S3_ACCESS_KEY", "minioadmin")
-    s3_secret_key: str = os.environ.get("S3_SECRET_KEY", "minioadmin")
-    s3_bucket: str = os.environ.get("S3_BUCKET", "ente-objects")
-    s3_use_path_style: bool = bool(int(os.environ.get("S3_USE_PATH_STYLE", "1")))
-    s3_presign_expiry: int = int(os.environ.get("S3_PRESIGN_EXPIRY", "3600"))
-    
-    # Multi-cloud S3 buckets (for Ente compatibility)
-    s3_b2_eu_cen_bucket: str = os.environ.get("S3_B2_EU_CEN_BUCKET", "ente-b2-eu-cen")
-    s3_wasabi_eu_central_bucket: str = os.environ.get("S3_WASABI_EU_CENTRAL_BUCKET", "ente-wasabi-eu")
-    s3_scw_eu_fr_bucket: str = os.environ.get("S3_SCW_EU_FR_BUCKET", "ente-scw-eu")
-    
-    # App Endpoints (Ente compatibility)
-    albums_base_url: str = os.environ.get("ALBUMS_BASE_URL", "http://localhost:3002")
-    cast_base_url: str = os.environ.get("CAST_BASE_URL", "http://localhost:3003")
-    accounts_base_url: str = os.environ.get("ACCOUNTS_BASE_URL", "http://localhost:3001")
-    
-    # Email Configuration
-    smtp_host: str = os.environ.get("SMTP_HOST", "")
-    smtp_port: int = int(os.environ.get("SMTP_PORT", "587"))
-    smtp_username: str = os.environ.get("SMTP_USERNAME", "")
-    smtp_password: str = os.environ.get("SMTP_PASSWORD", "")
-    smtp_from_email: str = os.environ.get("SMTP_FROM_EMAIL", "")
-    smtp_from_name: str = os.environ.get("SMTP_FROM_NAME", "Ente")
-    
-    # Encryption Keys (Ente compatibility)
-    key_encryption: str = os.environ.get("KEY_ENCRYPTION", "dev-encryption-key")
-    key_hash: str = os.environ.get("KEY_HASH", "dev-hash-key")
-    
-    # Accounts JWT for WebView bridge
-    accounts_jwt_secret: str = os.environ.get("ACCOUNTS_JWT_SECRET", "")
-    accounts_jwt_iss: str = os.environ.get("ACCOUNTS_JWT_ISS", "museum")
-    accounts_jwt_aud: str = os.environ.get("ACCOUNTS_JWT_AUD", "ente-accounts")
-    accounts_jwt_ttl_sec: int = int(os.environ.get("ACCOUNTS_JWT_TTL_SEC", "900"))
-    
-    # Feature Flags
-    enable_email_verification: bool = bool(int(os.environ.get("ENABLE_EMAIL_VERIFICATION", "0")))
-    enable_public_sharing: bool = bool(int(os.environ.get("ENABLE_PUBLIC_SHARING", "1")))
-    enable_family_plans: bool = bool(int(os.environ.get("ENABLE_FAMILY_PLANS", "0")))
-    
-    # Rate Limiting
-    rate_limit_enabled: bool = bool(int(os.environ.get("RATE_LIMIT_ENABLED", "1")))
-    rate_limit_requests_per_minute: int = int(os.environ.get("RATE_LIMIT_REQUESTS_PER_MINUTE", "60"))
 
-settings = Settings()
+    # JWT Configuration
+    jwt_secret: str = "dev-secret"
+    jwt_issuer: str = "museum-subset"
+    jwt_exp_hours: int = 24
+
+    # Admin Configuration
+    admin_email: str = "admin@example.com"
+    admin_password: str = "changeme"
+
+    # Database Configuration
+    # Use a simple SQLite file by default; override via `database_url` in config or env
+    database_url: str = "sqlite:///./ente.db"
+
+    # S3 / MinIO Configuration
+    s3_enabled: bool = True
+    s3_endpoint_url: str = "http://localhost:9000"
+    s3_region: str = "us-east-1"
+    s3_access_key: str = "minioadmin"
+    s3_secret_key: str = "minioadmin"
+    s3_bucket: str | None = None
+    s3_use_path_style: bool = True
+    s3_presign_expiry: int = 3600
+
+    # Dynamic multi-backend configuration
+    s3_backends: dict[str, dict[str, str]] = Field(default_factory=dict)
+
+    # App Endpoints (Ente compatibility)
+    albums_base_url: str = "http://localhost:3002"
+    cast_base_url: str = "http://localhost:3003"
+    accounts_base_url: str = "http://localhost:3001"
+
+    # Email Configuration
+    smtp_host: str = ""
+    smtp_port: int = 587
+    smtp_username: str = ""
+    smtp_password: str = ""
+    smtp_from_email: str = ""
+    smtp_from_name: str = "Ente"
+
+    # Encryption Keys (Ente compatibility)
+    key_encryption: str = "dev-encryption-key"
+    key_hash: str = "dev-hash-key"
+
+    # Accounts JWT for WebView bridge
+    accounts_jwt_secret: str = ""
+    accounts_jwt_iss: str = "museum"
+    accounts_jwt_aud: str = "ente-accounts"
+    accounts_jwt_ttl_sec: int = 900
+
+    # Feature Flags
+    enable_email_verification: bool = False
+    enable_public_sharing: bool = True
+    enable_family_plans: bool = False
+
+    # Rate Limiting
+    rate_limit_enabled: bool = True
+    rate_limit_requests_per_minute: int = 60
+
+
+def _load_from_toml() -> dict:
+    path = os.environ.get("CONFIG_FILE", "config.toml")
+    if not os.path.exists(path):
+        return {}
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    s3_section = data.get("s3", {})
+    backends = s3_section.pop("backends", None)
+    flat: dict[str, object] = {}
+    if backends:
+        flat["s3_backends"] = backends
+    for key, value in data.items():
+        if isinstance(value, dict):
+            for subkey, subval in value.items():
+                flat[f"{key}_{subkey}"] = subval
+        else:
+            flat[key] = value
+    return flat
+
+
+def load_settings() -> Settings:
+    data = _load_from_toml()
+    for field in Settings.model_fields:
+        env_var = field.upper()
+        if env_var in os.environ:
+            data[field] = os.environ[env_var]
+    return Settings(**data)
+
+settings = load_settings()

--- a/app/main.py
+++ b/app/main.py
@@ -61,8 +61,9 @@ def healthz():
     try:
         if settings.s3_enabled:
             client = s3mod._client()
-            # try listing bucket (lightweight)
-            client.list_objects_v2(Bucket=settings.s3_bucket, MaxKeys=1)
+            bucket = s3mod._bucket()
+            if bucket:
+                client.list_objects_v2(Bucket=bucket, MaxKeys=1)
             s3_status = "ok"
     except Exception as e:
         s3_status = f"error: {type(e).__name__}"

--- a/app/routers/storage.py
+++ b/app/routers/storage.py
@@ -10,7 +10,7 @@ from ..storage import (
     set_user_storage_quota, add_storage_bonus, format_storage_size,
     get_tier_quota_for_user, get_user_replica_usage
 )
-from ..s3 import get_available_tiers_for_subscription, StorageTier
+from ..s3 import get_available_tiers_for_subscription
 
 router = APIRouter(prefix="/storage", tags=["storage"])
 
@@ -79,35 +79,11 @@ def get_tier_quotas(current_user: User = Depends(get_current_user)):
 def get_replication_info(current_user: User = Depends(get_current_user)):
     """Get replication information and available tiers for user"""
     available_tiers = get_available_tiers_for_subscription(current_user.subscription_type)
-    
-    replication_rules = {
-        "free": "Full replication: PRIMARY → SECONDARY → COLD (equal for all)",
-        "paid": "Full replication: PRIMARY → SECONDARY → COLD (equal for all)",
-        "family": "Full replication: PRIMARY → SECONDARY → COLD (equal for all)"
-    }
-    
+
     return {
         "subscription_type": current_user.subscription_type,
-        "available_tiers": [tier.value for tier in available_tiers],
-        "replication_rule": replication_rules.get(current_user.subscription_type, "Unknown"),
-        "automatic_replication": True,  # All users get automatic replication
-        "tier_details": {
-            "primary": {
-                "name": "Primary Storage",
-                "description": "Hot storage for active files (counts against quota)",
-                "available": StorageTier.PRIMARY in available_tiers
-            },
-            "secondary": {
-                "name": "Secondary Storage", 
-                "description": "Hot backup storage for redundancy (free)",
-                "available": StorageTier.SECONDARY in available_tiers
-            },
-            "cold": {
-                "name": "Cold Storage",
-                "description": "Archive storage for long-term retention (free)", 
-                "available": StorageTier.COLD in available_tiers
-            }
-        }
+        "available_tiers": available_tiers,
+        "automatic_replication": True,
     }
 
 @router.get("/detailed-usage")

--- a/app/s3.py
+++ b/app/s3.py
@@ -1,165 +1,137 @@
-
 from __future__ import annotations
 import boto3
 import logging
-import asyncio
-import threading
-from enum import Enum
 from typing import Optional, Dict, Any, List
 from botocore.client import Config as BotoConfig
 from .config import settings
 
 logger = logging.getLogger(__name__)
 
-class StorageTier(Enum):
-    PRIMARY = "primary"  # B2 EU Central - Hot storage
-    SECONDARY = "secondary"  # Wasabi EU Central - Hot storage backup
-    COLD = "cold"  # Scaleway EU France - Cold storage
-
 class MultiCloudS3:
-    """Multi-cloud S3 implementation for Ente Museum compatibility"""
-    
+    """Dynamic multi-backend S3 implementation"""
+
     def __init__(self):
-        self.clients = self._init_clients()
-        self.buckets = {
-            StorageTier.PRIMARY: settings.s3_b2_eu_cen_bucket,
-            StorageTier.SECONDARY: settings.s3_wasabi_eu_central_bucket,
-            StorageTier.COLD: settings.s3_scw_eu_fr_bucket,
-        }
-    
-    def _init_clients(self) -> Dict[StorageTier, Any]:
-        """Initialize S3 clients for different storage tiers"""
-        clients = {}
-        
-        # Primary client (current single-cloud setup)
-        clients[StorageTier.PRIMARY] = boto3.client(
-            "s3",
-            aws_access_key_id=settings.s3_access_key,
-            aws_secret_access_key=settings.s3_secret_key,
-            endpoint_url=settings.s3_endpoint_url,
-            region_name=settings.s3_region,
-            config=BotoConfig(
-                signature_version="s3v4", 
-                s3={"addressing_style": "path" if settings.s3_use_path_style else "virtual"}
-            ),
-        )
-        
-        # For now, use the same client for all tiers (can be extended)
-        clients[StorageTier.SECONDARY] = clients[StorageTier.PRIMARY]
-        clients[StorageTier.COLD] = clients[StorageTier.PRIMARY]
-        
-        return clients
-    
-    def get_client(self, tier: StorageTier = StorageTier.PRIMARY):
-        """Get S3 client for specific storage tier"""
+        self.clients: Dict[str, Any] = {}
+        self.buckets: Dict[str, str] = {}
+        self._init_backends()
+
+    def _init_backends(self) -> None:
+        backends = settings.s3_backends or {}
+
+        if backends:
+            for name, cfg in backends.items():
+                client = boto3.client(
+                    "s3",
+                    aws_access_key_id=cfg.get("access_key", settings.s3_access_key),
+                    aws_secret_access_key=cfg.get("secret_key", settings.s3_secret_key),
+                    endpoint_url=cfg.get("endpoint_url", settings.s3_endpoint_url),
+                    region_name=cfg.get("region", settings.s3_region),
+                    config=BotoConfig(
+                        signature_version="s3v4",
+                        s3={"addressing_style": "path" if settings.s3_use_path_style else "virtual"},
+                    ),
+                )
+                self.clients[name] = client
+                self.buckets[name] = cfg.get("bucket", settings.s3_bucket or "")
+        else:
+            client = boto3.client(
+                "s3",
+                aws_access_key_id=settings.s3_access_key,
+                aws_secret_access_key=settings.s3_secret_key,
+                endpoint_url=settings.s3_endpoint_url,
+                region_name=settings.s3_region,
+                config=BotoConfig(
+                    signature_version="s3v4",
+                    s3={"addressing_style": "path" if settings.s3_use_path_style else "virtual"},
+                ),
+            )
+            self.clients["main"] = client
+            self.buckets["main"] = settings.s3_bucket or ""
+
+    def get_client(self, tier: str = "main"):
         return self.clients[tier]
-    
-    def get_bucket(self, tier: StorageTier = StorageTier.PRIMARY) -> str:
-        """Get bucket name for specific storage tier"""
-        return self.buckets.get(tier, settings.s3_bucket)
-    
-    def get_replication_targets(self, subscription_type: str, source_tier: StorageTier) -> List[StorageTier]:
-        """Get target tiers for replication - all users get full replication"""
-        targets = []
-        
-        # All users get full replication regardless of subscription
-        if source_tier == StorageTier.PRIMARY:
-            targets.extend([StorageTier.SECONDARY, StorageTier.COLD])
-        elif source_tier == StorageTier.SECONDARY:
-            targets.append(StorageTier.COLD)
-        
-        return targets
-    
-    def copy_object_between_buckets(self, key: str, source_tier: StorageTier, target_tier: StorageTier) -> bool:
-        """Copy object from source tier to target tier"""
+
+    def get_bucket(self, tier: str = "main") -> str:
+        return self.buckets[tier]
+
+    def get_replication_targets(self, subscription_type: str, source_tier: str) -> List[str]:
+        return [t for t in self.clients.keys() if t != source_tier]
+
+    def copy_object_between_buckets(self, key: str, source_tier: str, target_tier: str) -> bool:
         try:
             source_bucket = self.get_bucket(source_tier)
             target_bucket = self.get_bucket(target_tier)
             source_client = self.get_client(source_tier)
             target_client = self.get_client(target_tier)
-            
-            # For now, if buckets are the same (single S3 setup), just log
+
             if source_bucket == target_bucket:
-                logger.info(f"Simulated replication: {key} from {source_tier.value} to {target_tier.value}")
+                logger.info(f"Simulated replication: {key} from {source_tier} to {target_tier}")
                 return True
-            
-            # Copy object from source to target
-            copy_source = {'Bucket': source_bucket, 'Key': key}
-            target_client.copy_object(
-                CopySource=copy_source,
-                Bucket=target_bucket,
-                Key=key
-            )
-            
-            logger.info(f"Successfully replicated {key} from {source_tier.value} to {target_tier.value}")
+
+            copy_source = {"Bucket": source_bucket, "Key": key}
+            target_client.copy_object(CopySource=copy_source, Bucket=target_bucket, Key=key)
+
+            logger.info(f"Successfully replicated {key} from {source_tier} to {target_tier}")
             return True
-            
         except Exception as e:
-            logger.error(f"Failed to replicate {key} from {source_tier.value} to {target_tier.value}: {e}")
+            logger.error(f"Failed to replicate {key} from {source_tier} to {target_tier}: {e}")
             return False
-    
-    def replicate_to_tiers(self, key: str, subscription_type: str, source_tier: StorageTier = StorageTier.PRIMARY, original_file=None, db=None) -> Dict[str, bool]:
-        """Replicate object to appropriate tiers based on subscription"""
+
+    def replicate_to_tiers(self, key: str, subscription_type: str, source_tier: str = "main", original_file=None, db=None) -> Dict[str, bool]:
         targets = self.get_replication_targets(subscription_type, source_tier)
-        results = {}
-        
+        results: Dict[str, bool] = {}
+
         for target_tier in targets:
             success = self.copy_object_between_buckets(key, source_tier, target_tier)
-            results[target_tier.value] = success
-            
-            # Create replica file record if replication succeeded and we have the original file
+            results[target_tier] = success
+
             if success and original_file and db:
                 try:
                     from .storage import create_replica_file_record
-                    create_replica_file_record(original_file, target_tier.value, db)
-                    logger.info(f"Created replica record for {key} in {target_tier.value} tier")
+                    create_replica_file_record(original_file, target_tier, db)
+                    logger.info(f"Created replica record for {key} in {target_tier} tier")
                 except Exception as e:
-                    logger.error(f"Failed to create replica record for {key} in {target_tier.value}: {e}")
-        
+                    logger.error(f"Failed to create replica record for {key} in {target_tier}: {e}")
+
         return results
-    
-    def replicate_to_all_tiers(self, key: str, subscription_type: str = "free", source_tier: StorageTier = StorageTier.PRIMARY) -> bool:
-        """Replicate object to all appropriate tiers based on subscription"""
+
+    def replicate_to_all_tiers(self, key: str, subscription_type: str = "free", source_tier: str = "main") -> bool:
         results = self.replicate_to_tiers(key, subscription_type, source_tier)
-        
+
         if not results:
             logger.info(f"No replication targets for {subscription_type} subscription")
             return True
-        
+
         success_count = sum(1 for success in results.values() if success)
         total_count = len(results)
-        
+
         logger.info(f"Replication completed for {key}: {success_count}/{total_count} successful")
         return success_count == total_count
 
 # Global multi-cloud S3 instance
 _multicloud_s3 = MultiCloudS3()
 
-def _client(tier: StorageTier = StorageTier.PRIMARY):
-    """Get S3 client for specific tier (backward compatibility)"""
+def _client(tier: str = "main"):
+    """Get S3 client for specific tier"""
     return _multicloud_s3.get_client(tier)
 
-def _bucket(tier: StorageTier = StorageTier.PRIMARY) -> str:
+def _bucket(tier: str = "main") -> str:
     """Get bucket name for specific tier"""
     return _multicloud_s3.get_bucket(tier)
 
-def presign_put(key: str, content_type: str | None = None, expires: int | None = None, tier: StorageTier = StorageTier.PRIMARY) -> str:
-    """Generate presigned PUT URL for uploading to specific storage tier"""
+def presign_put(key: str, content_type: str | None = None, expires: int | None = None, tier: str = "main") -> str:
     params = {"Bucket": _bucket(tier), "Key": key}
     if content_type:
         params["ContentType"] = content_type
     return _client(tier).generate_presigned_url("put_object", Params=params, ExpiresIn=expires or settings.s3_presign_expiry, HttpMethod="PUT")
 
-def presign_get(key: str, response_filename: str | None = None, expires: int | None = None, tier: StorageTier = StorageTier.PRIMARY) -> str:
-    """Generate presigned GET URL with tier fallback for downloads"""
-    # Try primary tier first, fallback to secondary if needed
-    for fallback_tier in [tier, StorageTier.PRIMARY, StorageTier.SECONDARY]:
+def presign_get(key: str, response_filename: str | None = None, expires: int | None = None, tier: str = "main") -> str:
+    tiers = [tier] + [t for t in _multicloud_s3.clients.keys() if t != tier]
+    for fallback_tier in tiers:
         try:
             params = {"Bucket": _bucket(fallback_tier), "Key": key}
             if response_filename:
                 params["ResponseContentDisposition"] = f'attachment; filename="{response_filename}"'
-            
-            # Check if object exists in this tier
             try:
                 _client(fallback_tier).head_object(Bucket=_bucket(fallback_tier), Key=key)
                 return _client(fallback_tier).generate_presigned_url("get_object", Params=params, ExpiresIn=expires or settings.s3_presign_expiry, HttpMethod="GET")
@@ -167,65 +139,51 @@ def presign_get(key: str, response_filename: str | None = None, expires: int | N
                 continue
         except Exception:
             continue
-    
-    # Fallback to primary tier if all else fails
-    params = {"Bucket": _bucket(StorageTier.PRIMARY), "Key": key}
+    params = {"Bucket": _bucket("main"), "Key": key}
     if response_filename:
         params["ResponseContentDisposition"] = f'attachment; filename="{response_filename}"'
-    return _client(StorageTier.PRIMARY).generate_presigned_url("get_object", Params=params, ExpiresIn=expires or settings.s3_presign_expiry, HttpMethod="GET")
+    return _client("main").generate_presigned_url("get_object", Params=params, ExpiresIn=expires or settings.s3_presign_expiry, HttpMethod="GET")
 
-def mpu_init(key: str, tier: StorageTier = StorageTier.PRIMARY) -> str:
-    """Initialize multipart upload on specific storage tier"""
+def mpu_init(key: str, tier: str = "main") -> str:
     out = _client(tier).create_multipart_upload(Bucket=_bucket(tier), Key=key)
     return out["UploadId"]
 
-def mpu_presign_part(key: str, upload_id: str, part_number: int, expires: int | None = None, tier: StorageTier = StorageTier.PRIMARY) -> str:
-    """Generate presigned URL for multipart upload part"""
+def mpu_presign_part(key: str, upload_id: str, part_number: int, expires: int | None = None, tier: str = "main") -> str:
     return _client(tier).generate_presigned_url(
         "upload_part",
         Params={"Bucket": _bucket(tier), "Key": key, "UploadId": upload_id, "PartNumber": part_number},
         ExpiresIn=expires or settings.s3_presign_expiry,
-        HttpMethod="PUT"
+        HttpMethod="PUT",
     )
 
-def mpu_complete(key: str, upload_id: str, parts: list[dict], tier: StorageTier = StorageTier.PRIMARY, subscription_type: str = "free"):
-    """Complete multipart upload and trigger replication"""
+def mpu_complete(key: str, upload_id: str, parts: list[dict], tier: str = "main", subscription_type: str = "free"):
     result = _client(tier).complete_multipart_upload(
         Bucket=_bucket(tier),
         Key=key,
         UploadId=upload_id,
-        MultipartUpload={"Parts": parts}
+        MultipartUpload={"Parts": parts},
     )
-    
-    # Automatically replicate to appropriate tiers based on subscription
     _multicloud_s3.replicate_to_all_tiers(key, subscription_type, tier)
-    
     return result
 
 def delete_object(key: str, all_tiers: bool = True) -> bool:
-    """Delete object from one or all storage tiers"""
     success = True
-    
     if all_tiers:
-        # Delete from all tiers
-        for tier in StorageTier:
+        for tier in list(_multicloud_s3.clients.keys()):
             try:
                 _client(tier).delete_object(Bucket=_bucket(tier), Key=key)
-                logger.info(f"Deleted {key} from {tier.value} tier")
+                logger.info(f"Deleted {key} from {tier} tier")
             except Exception as e:
-                logger.warning(f"Failed to delete {key} from {tier.value} tier: {e}")
+                logger.warning(f"Failed to delete {key} from {tier} tier: {e}")
                 success = False
     else:
-        # Delete from primary tier only
         try:
-            _client(StorageTier.PRIMARY).delete_object(Bucket=_bucket(StorageTier.PRIMARY), Key=key)
+            _client("main").delete_object(Bucket=_bucket("main"), Key=key)
         except Exception:
             success = False
-    
     return success
 
-def get_object_info(key: str, tier: StorageTier = StorageTier.PRIMARY) -> Optional[Dict[str, Any]]:
-    """Get object metadata from specific storage tier"""
+def get_object_info(key: str, tier: str = "main") -> Optional[Dict[str, Any]]:
     try:
         response = _client(tier).head_object(Bucket=_bucket(tier), Key=key)
         return {
@@ -237,23 +195,17 @@ def get_object_info(key: str, tier: StorageTier = StorageTier.PRIMARY) -> Option
     except Exception:
         return None
 
-def replicate_object(key: str, source_tier: StorageTier, target_tier: StorageTier) -> bool:
-    """Replicate object between storage tiers"""
+def replicate_object(key: str, source_tier: str, target_tier: str) -> bool:
     return _multicloud_s3.copy_object_between_buckets(key, source_tier, target_tier)
 
-def replicate_after_upload(key: str, subscription_type: str, tier: StorageTier = StorageTier.PRIMARY, original_file=None, db=None) -> Dict[str, bool]:
-    """Automatically replicate object after upload based on subscription"""
+def replicate_after_upload(key: str, subscription_type: str, tier: str = "main", original_file=None, db=None) -> Dict[str, bool]:
     return _multicloud_s3.replicate_to_tiers(key, subscription_type, tier, original_file, db)
 
-def get_available_tiers_for_subscription(subscription_type: str) -> List[StorageTier]:
-    """Get list of available storage tiers - all users get all tiers"""
-    # All users get access to all storage tiers regardless of subscription
-    return [StorageTier.PRIMARY, StorageTier.SECONDARY, StorageTier.COLD]
+def get_available_tiers_for_subscription(subscription_type: str) -> List[str]:
+    return list(_multicloud_s3.clients.keys())
 
-# Backward compatibility functions
 def head_object_size_and_etag(key: str) -> tuple[Optional[int], Optional[str]]:
-    """Get object size and etag with tier fallback"""
-    for tier in StorageTier:
+    for tier in _multicloud_s3.clients.keys():
         info = get_object_info(key, tier)
         if info:
             return info["size"], info["etag"]

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,21 @@
+# Example configuration for EnteServer
+
+jwt_secret = "dev-secret"
+admin_email = "admin@example.com"
+admin_password = "changeme"
+database_url = "sqlite:///./ente.db"
+
+[s3]
+enabled = true
+endpoint_url = "http://localhost:9000"
+region = "us-east-1"
+access_key = "minioadmin"
+secret_key = "minioadmin"
+use_path_style = true
+presign_expiry = 3600
+
+[s3.backends.main]
+bucket = "app-main"
+
+[s3.backends.backup]
+bucket = "app-backup"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,20 +8,11 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=sqlite:///./museum.db
-      - S3_ENDPOINT_URL=http://minio:9000
-      - S3_ACCESS_KEY=minioadmin
-      - S3_SECRET_KEY=minioadmin
-      - S3_BUCKET=ente-objects
-      - S3_REGION=us-east-1
-      - S3_USE_PATH_STYLE=1
-      - ALBUMS_BASE_URL=http://localhost:3002
-      - JWT_SECRET=your-secret-key-change-in-production
-      - ADMIN_EMAIL=admin@example.com
-      - ADMIN_PASSWORD=admin123
+      - CONFIG_FILE=/app/config.toml
     volumes:
-      - ./museum.db:/app/museum.db
+      - ./ente.db:/app/ente.db
       - ./logs:/app/logs
+      - ./config.toml:/app/config.toml:ro
     depends_on:
       - minio
     restart: unless-stopped
@@ -58,8 +49,9 @@ services:
       /bin/sh -c "
       sleep 10;
       /usr/bin/mc alias set myminio http://minio:9000 minioadmin minioadmin;
-      /usr/bin/mc mb myminio/ente-objects --ignore-existing;
-      /usr/bin/mc policy set public myminio/ente-objects;
+      /usr/bin/mc mb myminio/app-main --ignore-existing;
+      /usr/bin/mc mb myminio/app-backup --ignore-existing;
+      /usr/bin/mc policy set public myminio/app-main;
       echo 'MinIO bucket setup completed';
       "
 


### PR DESCRIPTION
## Summary
- load settings from optional `config.toml` with environment variable overrides
- document and mount example TOML config including multiple S3 backends
- simplify docker compose and runtime setup to rely on the config file
- drop museum-specific sqlite path in favor of `ente.db`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c523117dc48333850a61458ad4531b