### PR TITLE
Add one-click deploy configs for Railway and Vercel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/ping || exit 1
 
 # Default command
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]
 
 # Labels for metadata
 LABEL maintainer="Ente Museum Server" \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Original https://github.com/ente-io/ente/tree/main/server
 We are trying to be compatible, provide a lighrter, easier to use server.
 There is a docker file but I highly recommend you just use the py version, its faster, and you should change settings.
 
-
 Run:
 
 ```bash
@@ -35,3 +34,16 @@ python -m app.cli show-storage-usage --email user@example.com
 python -m app.cli refresh-storage-usage --email user@example.com
 python -m app.cli set-subscription --email user@example.com --type paid (Just a tier name, IAP money goes to ente)
 ```
+
+## One-click deploy
+
+Quickly run this server on popular hosting platforms:
+
+### Railway
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https://github.com/yourusername/enteserver)
+
+### Vercel
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/yourusername/enteserver)
+

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE"
+  },
+  "deploy": {
+    "startCommand": "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    { "src": "Dockerfile", "use": "@vercel/docker" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow Docker container port to respect `PORT`
- add Railway and Vercel deployment configs
- document one-click deploy links
- move one-click deploy section to bottom of README

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6c2e42cec8333b4b3c088e5d48c52