### PR TITLE
Serve local storage URLs from the API host and centralize configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ uvicorn app.main:app --reload
 # Swagger: http://localhost:8000/docs
 ```
 
+### Configuration
+
+Runtime configuration is centralized through the `app/config` package. Edit
+`config.toml` (or point the `CONFIG_FILE` environment variable to another
+TOML file) to override settings; the Python modules import the generated
+`Settings` object from `app.config`. This keeps a single source of truth for
+application options while still giving tests and scripts a convenient
+`config.override(...)` helper when temporary adjustments are required.
+
+### Object storage configuration
+
+The server now supports multiple storage backends simultaneously. Each backend
+can be an S3-compatible service or a local filesystem path. Define the desired
+mix of backends in the `[s3.backends]` section of `config.toml`. For example,
+you can configure a local directory as the primary tier and still replicate
+objects to a remote S3 bucket, or use multiple local folders for additional
+redundancy. See `config.example.toml` for a sample configuration that combines
+an S3 bucket with a local path. When a local backend is active the server
+exposes signed URLs under `/local-storage/...` that behave like S3 presigned
+links for uploads, downloads, and multipart uploads. These endpoints are served
+by the FastAPI app itself so all storage traffic stays on the same port as the
+rest of the API.
+
 CLI:
 
 ```bash

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Generator, Mapping
+
+from .manager import ConfigManager
+from .models import Settings
+
+__all__ = [
+    "Settings",
+    "settings",
+    "get_settings",
+    "reload_settings",
+    "config_path",
+    "as_dict",
+    "override",
+]
+
+_manager = ConfigManager()
+settings: Settings = _manager.settings
+
+
+def get_settings() -> Settings:
+    return settings
+
+
+def reload_settings(*, overrides: Mapping[str, Any] | None = None) -> Settings:
+    global settings
+    settings = _manager.reload(overrides=overrides)
+    return settings
+
+
+def config_path() -> Path:
+    return _manager.config_path
+
+
+def as_dict() -> dict[str, Any]:
+    return _manager.as_dict()
+
+
+@contextmanager
+def override(**values: Any) -> Generator[Settings, None, None]:
+    global settings
+    previous = _manager.settings
+    try:
+        settings = _manager.reload(overrides=values)
+        yield settings
+    finally:
+        settings = _manager.replace(previous)

--- a/app/config/manager.py
+++ b/app/config/manager.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from threading import RLock
+from typing import Any, Mapping
+
+from .models import Settings
+from .sources import env_overrides, load_from_toml
+
+
+class ConfigManager:
+    """Central coordinator for loading and reloading application settings."""
+
+    def __init__(self, *, env_var: str = "CONFIG_FILE", default_file: str = "config.toml") -> None:
+        self._env_var = env_var
+        self._default_file = default_file
+        self._lock = RLock()
+        self._settings = self._load()
+
+    @property
+    def settings(self) -> Settings:
+        return self._settings
+
+    @property
+    def config_path(self) -> Path:
+        return self._resolve_config_path()
+
+    def reload(self, *, overrides: Mapping[str, Any] | None = None) -> Settings:
+        with self._lock:
+            self._settings = self._load(overrides)
+            return self._settings
+
+    def replace(self, new_settings: Settings) -> Settings:
+        with self._lock:
+            self._settings = new_settings
+            return self._settings
+
+    def as_dict(self) -> dict[str, Any]:
+        with self._lock:
+            return self._settings.model_dump()
+
+    def _resolve_config_path(self) -> Path:
+        candidate = os.environ.get(self._env_var, self._default_file)
+        return Path(candidate)
+
+    def _load(self, overrides: Mapping[str, Any] | None = None) -> Settings:
+        data = load_from_toml(self._resolve_config_path())
+        data.update(env_overrides(Settings, os.environ))
+        if overrides:
+            data.update(overrides)
+        return Settings(**data)

--- a/app/config/models.py
+++ b/app/config/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-import os
-import tomllib
+
 from pydantic import BaseModel, Field
+
 
 class Settings(BaseModel):
     app_name: str = "Museum‑subset (FastAPI)"
@@ -63,34 +63,3 @@ class Settings(BaseModel):
     # Rate Limiting
     rate_limit_enabled: bool = True
     rate_limit_requests_per_minute: int = 60
-
-
-def _load_from_toml() -> dict:
-    path = os.environ.get("CONFIG_FILE", "config.toml")
-    if not os.path.exists(path):
-        return {}
-    with open(path, "rb") as f:
-        data = tomllib.load(f)
-    s3_section = data.get("s3", {})
-    backends = s3_section.pop("backends", None)
-    flat: dict[str, object] = {}
-    if backends:
-        flat["s3_backends"] = backends
-    for key, value in data.items():
-        if isinstance(value, dict):
-            for subkey, subval in value.items():
-                flat[f"{key}_{subkey}"] = subval
-        else:
-            flat[key] = value
-    return flat
-
-
-def load_settings() -> Settings:
-    data = _load_from_toml()
-    for field in Settings.model_fields:
-        env_var = field.upper()
-        if env_var in os.environ:
-            data[field] = os.environ[env_var]
-    return Settings(**data)
-
-settings = load_settings()

--- a/app/config/sources.py
+++ b/app/config/sources.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Type
+
+import tomllib
+from pydantic import BaseModel
+
+
+def load_from_toml(path: str | Path | None) -> dict[str, Any]:
+    if not path:
+        return {}
+
+    file_path = Path(path)
+    if not file_path.exists():
+        return {}
+
+    with file_path.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    flattened: dict[str, Any] = {}
+    for key, value in data.items():
+        if isinstance(value, MutableMapping):
+            if key == "s3":
+                backends = value.get("backends")
+                if backends:
+                    flattened["s3_backends"] = backends
+                value = {subkey: subval for subkey, subval in value.items() if subkey != "backends"}
+            for subkey, subval in value.items():
+                flattened[f"{key}_{subkey}"] = subval
+        else:
+            flattened[key] = value
+    return flattened
+
+
+def env_overrides(model: Type[BaseModel], environ: Mapping[str, str]) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    for field in model.model_fields:
+        env_key = field.upper()
+        if env_key in environ:
+            overrides[field] = environ[env_key]
+    return overrides

--- a/app/local_s3.py
+++ b/app/local_s3.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import mimetypes
+import shutil
+import time
+import uuid
+from pathlib import Path
+from typing import AsyncIterator, Dict, Iterable, Optional
+
+from botocore.exceptions import ClientError
+
+
+class LocalS3Error(RuntimeError):
+    """Internal error raised for invalid local S3 operations."""
+
+
+class LocalS3Client:
+    """Minimal S3-compatible interface backed by the local filesystem."""
+
+    def __init__(
+        self,
+        name: str,
+        base_path: str,
+        *,
+        base_url: str | None = None,
+        secret: str,
+    ) -> None:
+        self.name = name
+        self.base_path = Path(base_path).expanduser().resolve()
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.base_url = base_url.rstrip("/") if base_url else ""
+        self._secret = secret.encode("utf-8")
+        self._multipart_dir = self.base_path / ".multipart"
+        self._multipart_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _normalize_key(self, key: str) -> str:
+        return key.lstrip("/")
+
+    def _object_path(self, key: str, *, create_parents: bool = True) -> Path:
+        normalized = self._normalize_key(key)
+        path = (self.base_path / normalized).resolve()
+        if not str(path).startswith(str(self.base_path)):
+            raise LocalS3Error("Attempted path traversal outside storage root")
+        if create_parents:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _existing_object_path(self, key: str) -> Path:
+        path = self._object_path(key, create_parents=False)
+        if not path.exists():
+            error_response = {"Error": {"Code": "404", "Message": "Not Found"}}
+            raise ClientError(error_response, "HeadObject")
+        return path
+
+    def _multipart_path(self, upload_id: str) -> Path:
+        upload_dir = (self._multipart_dir / upload_id).resolve()
+        if not str(upload_dir).startswith(str(self._multipart_dir)):
+            raise LocalS3Error("Invalid multipart upload identifier")
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        return upload_dir
+
+    def _multipart_meta_path(self, upload_id: str) -> Path:
+        return self._multipart_path(upload_id) / "meta.json"
+
+    def _sign(self, method: str, key: str, expires: int, extra: Optional[Dict[str, str]] = None) -> str:
+        normalized_key = self._normalize_key(key)
+        components = [method.upper(), self.name, normalized_key, str(expires)]
+        if extra:
+            for k in sorted(extra):
+                components.append(f"{k}={extra[k]}")
+        message = "\n".join(components).encode("utf-8")
+        return hmac.new(self._secret, message, hashlib.sha256).hexdigest()
+
+    def verify_signature(
+        self,
+        method: str,
+        key: str,
+        expires: int,
+        signature: str,
+        extra: Optional[Dict[str, str]] = None,
+    ) -> None:
+        if expires < int(time.time()):
+            raise LocalS3Error("URL expired")
+        expected = self._sign(method, key, expires, extra)
+        if not hmac.compare_digest(expected, signature):
+            raise LocalS3Error("Invalid signature")
+
+    # ------------------------------------------------------------------
+    # HTTP URL helpers
+    # ------------------------------------------------------------------
+    def _build_url(self, key: str, expires: int, params: Dict[str, str]) -> str:
+        from urllib.parse import urlencode, quote
+
+        encoded_key = quote(self._normalize_key(key), safe="/")
+        query = urlencode(params, quote_via=quote)
+        prefix = self.base_url or ""
+        return f"{prefix}/local-storage/{self.name}/{encoded_key}?{query}"
+
+    def generate_presigned_url(
+        self,
+        operation_name: str,
+        *,
+        Params: Dict[str, object],
+        ExpiresIn: int,
+        HttpMethod: str,
+    ) -> str:
+        key_value = Params.get("Key") if Params else None
+        key = str(key_value) if key_value is not None else f"{self.name}/health"
+        expires = int(time.time()) + int(ExpiresIn)
+        extra: Dict[str, str] = {}
+
+        if operation_name == "upload_part":
+            extra["uploadId"] = str(Params["UploadId"])
+            extra["partNumber"] = str(Params["PartNumber"])
+        elif operation_name == "get_object":
+            if "ResponseContentDisposition" in Params:
+                extra["response-content-disposition"] = str(Params["ResponseContentDisposition"])
+        params = dict(extra)
+        params["expires"] = str(expires)
+        params["signature"] = self._sign(HttpMethod, key, expires, extra)
+        return self._build_url(key, expires, params)
+
+    # ------------------------------------------------------------------
+    # Multipart upload helpers
+    # ------------------------------------------------------------------
+    def create_multipart_upload(self, *, Bucket: str | None, Key: str) -> Dict[str, str]:
+        upload_id = uuid.uuid4().hex
+        meta = {"Key": Key}
+        meta_path = self._multipart_meta_path(upload_id)
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_text(json.dumps(meta))
+        return {"UploadId": upload_id}
+
+    def _load_multipart_meta(self, upload_id: str) -> Dict[str, object]:
+        meta_path = self._multipart_meta_path(upload_id)
+        if not meta_path.exists():
+            raise LocalS3Error("Unknown multipart upload")
+        return json.loads(meta_path.read_text())
+
+    def store_multipart_part(self, upload_id: str, part_number: int, data: Iterable[bytes]) -> str:
+        self._load_multipart_meta(upload_id)
+        upload_dir = self._multipart_path(upload_id)
+        part_path = upload_dir / f"part_{part_number:05d}"
+        md5 = hashlib.md5()
+        with part_path.open("wb") as fh:
+            for chunk in data:
+                fh.write(chunk)
+                md5.update(chunk)
+        return md5.hexdigest()
+
+    async def store_multipart_part_async(self, upload_id: str, part_number: int, data: AsyncIterator[bytes]) -> str:
+        self._load_multipart_meta(upload_id)
+        upload_dir = self._multipart_path(upload_id)
+        part_path = upload_dir / f"part_{part_number:05d}"
+        md5 = hashlib.md5()
+        with part_path.open("wb") as fh:
+            async for chunk in data:
+                fh.write(chunk)
+                md5.update(chunk)
+        return md5.hexdigest()
+
+    def complete_multipart_upload(self, *, Bucket: str | None, Key: str, UploadId: str, MultipartUpload: Dict[str, object]):
+        self._load_multipart_meta(UploadId)
+        upload_dir = self._multipart_path(UploadId)
+        parts = MultipartUpload.get("Parts") or []
+        dest_path = self._object_path(Key)
+        md5 = hashlib.md5()
+        with dest_path.open("wb") as dest:
+            for part in sorted(parts, key=lambda p: p["PartNumber"]):
+                part_path = upload_dir / f"part_{part['PartNumber']:05d}"
+                if not part_path.exists():
+                    raise LocalS3Error(f"Missing part {part['PartNumber']}")
+                with part_path.open("rb") as src:
+                    while True:
+                        chunk = src.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        dest.write(chunk)
+                        md5.update(chunk)
+        shutil.rmtree(upload_dir, ignore_errors=True)
+        return {"ETag": md5.hexdigest()}
+
+    # ------------------------------------------------------------------
+    # Object helpers for HTTP handlers and replication
+    # ------------------------------------------------------------------
+    def save_object(self, key: str, data: Iterable[bytes]) -> str:
+        path = self._object_path(key)
+        md5 = hashlib.md5()
+        with path.open("wb") as fh:
+            for chunk in data:
+                fh.write(chunk)
+                md5.update(chunk)
+        return md5.hexdigest()
+
+    async def save_object_async(self, key: str, data: AsyncIterator[bytes]) -> str:
+        path = self._object_path(key)
+        md5 = hashlib.md5()
+        with path.open("wb") as fh:
+            async for chunk in data:
+                fh.write(chunk)
+                md5.update(chunk)
+        return md5.hexdigest()
+
+    def open_for_read(self, key: str):
+        path = self._existing_object_path(key)
+        return path.open("rb")
+
+    def write_fileobj(self, key: str, fileobj) -> None:
+        path = self._object_path(key)
+        with path.open("wb") as dest:
+            shutil.copyfileobj(fileobj, dest)
+
+    def open_for_write(self, key: str):
+        path = self._object_path(key)
+        return path.open("wb")
+
+    def copy_from_path(self, key: str, source_path: Path) -> None:
+        dest_path = self._object_path(key)
+        shutil.copy2(source_path, dest_path)
+
+    def head_object(self, *, Bucket: str | None, Key: str) -> Dict[str, object]:
+        try:
+            path = self._existing_object_path(Key)
+        except ClientError as exc:
+            raise exc
+        stat = path.stat()
+        content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        etag = self._compute_etag(path)
+        return {
+            "ContentLength": stat.st_size,
+            "ETag": etag,
+            "LastModified": time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime(stat.st_mtime)),
+            "ContentType": content_type,
+        }
+
+    def delete_object(self, *, Bucket: str | None, Key: str) -> None:
+        path = self._object_path(Key, create_parents=False)
+        if path.exists():
+            path.unlink()
+
+    def _compute_etag(self, path: Path) -> str:
+        md5 = hashlib.md5()
+        with path.open("rb") as fh:
+            while True:
+                chunk = fh.read(1024 * 1024)
+                if not chunk:
+                    break
+                md5.update(chunk)
+        return md5.hexdigest()
+
+    def get_existing_path(self, key: str) -> Path:
+        return self._existing_object_path(key)
+

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from .routers.trash import router as trash_router
 from .routers.storage import router as storage_router
 from .routers.admin_ui import router as admin_ui_router
 from .routers.invite import router as invite_router
+from .s3 import has_local_backend
 
 app = FastAPI(title="Museum-subset (FastAPI) with S3 presign, sessions, trash")
 
@@ -27,6 +28,10 @@ app.include_router(trash_router)
 app.include_router(storage_router)
 app.include_router(admin_ui_router)
 app.include_router(invite_router)
+if has_local_backend():
+    from .routers.local_storage import router as local_storage_router
+
+    app.include_router(local_storage_router)
 
 @app.get("/ping")
 def ping():

--- a/app/routers/local_storage.py
+++ b/app/routers/local_storage.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from botocore.exceptions import ClientError
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi.responses import StreamingResponse
+
+from ..local_s3 import LocalS3Error
+from ..s3 import get_local_client
+
+
+router = APIRouter(prefix="/local-storage", tags=["local-storage"])
+
+
+def _require_client(tier: str):
+    client = get_local_client(tier)
+    if not client:
+        raise HTTPException(status_code=404, detail="Unknown storage tier")
+    return client
+
+
+def _verify(client, method: str, key: str, expires: int, signature: str, extra: Dict[str, str] | None = None) -> None:
+    try:
+        client.verify_signature(method, key, expires, signature, extra)
+    except LocalS3Error as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+
+async def _async_body_chunks(request: Request):
+    async for chunk in request.stream():
+        if chunk:
+            yield chunk
+
+
+@router.put("/{tier}/{object_path:path}")
+async def upload_object(
+    tier: str,
+    object_path: str,
+    request: Request,
+    expires: int = Query(...),
+    signature: str = Query(...),
+    upload_id: str | None = Query(None, alias="uploadId"),
+    part_number: int | None = Query(None, alias="partNumber"),
+):
+    client = _require_client(tier)
+    extra: Dict[str, str] = {}
+    if upload_id:
+        extra["uploadId"] = upload_id
+    if part_number is not None:
+        if not upload_id:
+            raise HTTPException(status_code=400, detail="partNumber requires uploadId")
+        extra["partNumber"] = str(part_number)
+    elif upload_id:
+        raise HTTPException(status_code=400, detail="uploadId requires partNumber")
+
+    _verify(client, "PUT", object_path, expires, signature, extra)
+
+    try:
+        if upload_id:
+            etag = await client.store_multipart_part_async(upload_id, int(part_number), _async_body_chunks(request))
+        else:
+            etag = await client.save_object_async(object_path, _async_body_chunks(request))
+    except LocalS3Error as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    headers = {"ETag": f'"{etag}"'}
+    return Response(status_code=200, headers=headers)
+
+
+def _set_common_headers(response: Response, info: Dict[str, object], content_disposition: str | None) -> None:
+    response.headers["Content-Length"] = str(info.get("ContentLength", ""))
+    response.headers["ETag"] = f'"{info.get("ETag")}"'
+    if "LastModified" in info and info["LastModified"]:
+        response.headers["Last-Modified"] = str(info["LastModified"])
+    if content_disposition:
+        response.headers["Content-Disposition"] = content_disposition
+
+
+def _stream_file(client, key: str):
+    with client.open_for_read(key) as fh:
+        while True:
+            chunk = fh.read(1024 * 1024)
+            if not chunk:
+                break
+            yield chunk
+
+
+@router.get("/{tier}/{object_path:path}")
+async def download_object(
+    tier: str,
+    object_path: str,
+    expires: int = Query(...),
+    signature: str = Query(...),
+    response_disposition: str | None = Query(None, alias="response-content-disposition"),
+):
+    client = _require_client(tier)
+    extra: Dict[str, str] = {}
+    if response_disposition:
+        extra["response-content-disposition"] = response_disposition
+    _verify(client, "GET", object_path, expires, signature, extra)
+
+    try:
+        info = client.head_object(Bucket=None, Key=object_path)
+    except ClientError as exc:
+        raise HTTPException(status_code=404, detail="Object not found") from exc
+
+    response = StreamingResponse(
+        _stream_file(client, object_path),
+        media_type=info.get("ContentType") or "application/octet-stream",
+    )
+    _set_common_headers(response, info, response_disposition)
+    return response
+
+
+@router.head("/{tier}/{object_path:path}")
+async def head_object(
+    tier: str,
+    object_path: str,
+    expires: int = Query(...),
+    signature: str = Query(...),
+    response_disposition: str | None = Query(None, alias="response-content-disposition"),
+):
+    client = _require_client(tier)
+    extra: Dict[str, str] = {}
+    if response_disposition:
+        extra["response-content-disposition"] = response_disposition
+    _verify(client, "HEAD", object_path, expires, signature, extra)
+
+    try:
+        info = client.head_object(Bucket=None, Key=object_path)
+    except ClientError as exc:
+        raise HTTPException(status_code=404, detail="Object not found") from exc
+
+    response = Response(status_code=200)
+    response.headers["Content-Type"] = info.get("ContentType", "application/octet-stream")
+    _set_common_headers(response, info, response_disposition)
+    return response

--- a/config.example.toml
+++ b/config.example.toml
@@ -19,3 +19,10 @@ bucket = "app-main"
 
 [s3.backends.backup]
 bucket = "app-backup"
+
+[s3.backends.local]
+type = "local"
+base_path = "./object-storage"
+# Optional override for presigned URLs. When omitted the API host/port is used
+# automatically so local storage stays behind the same FastAPI server.
+# base_url = "http://localhost:8000"

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,5 +50,7 @@ features are stubs.  Use this server only for development and with test data.
 uvicorn app.main:app --reload
 ```
 
-The server uses a local SQLite database file and an S3-compatible object store. Configuration
-options are documented in `app/config.py` and can be provided via environment variables.
+The server uses a local SQLite database file and supports one or more object storage
+backends. Each backend can point to an S3-compatible service or a local filesystem
+path. Configuration options are documented in `app/config.py` and can be provided
+via environment variables.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,28 @@ class _DummyClient:
     def copy_object(self, *args, **kwargs):
         return {}
 
+    def upload_fileobj(self, *args, **kwargs):
+        return {}
+
+    def put_object(self, *args, **kwargs):
+        return {}
+
+    def download_fileobj(self, *args, **kwargs):
+        if len(args) >= 3:
+            fileobj = args[2]
+        else:
+            fileobj = kwargs.get("Fileobj")
+        if fileobj:
+            fileobj.write(b"")
+        return {}
+
+    def get_object(self, *args, **kwargs):
+        class _Body:
+            def read(self_inner):
+                return b""
+
+        return {"Body": _Body()}
+
 
 os.environ.setdefault("S3_BUCKET", "test-bucket")
 boto3.client = lambda *args, **kwargs: _DummyClient()

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,5 +1,7 @@
 import importlib
+
 import pytest
+from fastapi.testclient import TestClient
 from botocore.exceptions import ClientError
 
 
@@ -7,6 +9,7 @@ from botocore.exceptions import ClientError
 def s3_mod():
     import app.config as config
     import app.s3 as s3
+
     importlib.reload(config)
     importlib.reload(s3)
 
@@ -48,3 +51,53 @@ def test_multi_cloud_requires_backend_validation(s3_mod):
     s3.settings.s3_backends = {}
     with pytest.raises(ValueError):
         s3.MultiCloudS3()
+
+
+def test_local_backend_roundtrip(tmp_path):
+    import app.config as config
+    import app.s3 as s3
+    import app.main as main
+
+    importlib.reload(config)
+    try:
+        with config.override(
+            s3_backends={
+                "main": {
+                    "type": "local",
+                    "base_path": str(tmp_path),
+                    "base_url": "http://testserver",
+                }
+            }
+        ):
+            importlib.reload(s3)
+            importlib.reload(main)
+
+            client = TestClient(main.app)
+            put_url = s3.presign_put("1/sample.bin")
+            resp = client.put(put_url, data=b"hello world")
+            assert resp.status_code == 200
+            get_url = s3.presign_get("1/sample.bin")
+            resp = client.get(get_url)
+            assert resp.status_code == 200
+            assert resp.content == b"hello world"
+            assert "ETag" in resp.headers
+    finally:
+        importlib.reload(s3)
+        importlib.reload(main)
+
+
+def test_resolve_presigned_url_uses_request_host(tmp_path):
+    import app.s3 as s3
+    from app.local_s3 import LocalS3Client
+
+    client = LocalS3Client(name="primary", base_path=str(tmp_path), secret="secret")
+    raw_url = client.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": None, "Key": "1/sample.bin"},
+        ExpiresIn=60,
+        HttpMethod="PUT",
+    )
+
+    resolved = s3.resolve_presigned_url(raw_url, "http://example.com/api")
+    assert resolved.startswith("http://example.com/api/local-storage/primary/1/sample.bin")
+    assert "expires=" in resolved and "signature=" in resolved


### PR DESCRIPTION
## Summary
- ensure presigned URLs from local storage resolve against the FastAPI request host so uploads and downloads stay on a single port
- update file and public link routers to return absolute local-storage URLs and document the single-port configuration
- add unit coverage for resolving relative local storage URLs to absolute API URLs
- centralize configuration loading in the `app/config` package with a manager, TOML/environment sources, and a context-based override helper to remove confusion between `config.py` and `config.toml`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9717697cc8333b757a6d5baf31371